### PR TITLE
Fix headers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#FTPDB
+# FTPDB
 
 
-##Features
+## Features
 
 
 - Works well with a variety of clients.
 - Supports multiple simultaneous clients. The 3DS itself only appears to support enough sockets to perform 4-5 simultaneous data transfers, so it will help if you limit your FTP client to this many parallel requests.
 
-##Latest Builds
+## Latest Builds
 
 
 
@@ -15,7 +15,7 @@ CIA: [click here](https://github.com/Favna/FTPDB/releases/download/1.4.1/FTPDB.c
 
 3DSX: [click here](https://github.com/Favna/FTPDB/releases/download/1.4.1/FTPDB.zip)
 
-##Building
+## Building
 
 
 Install and set up [devkitARM and libctru](http://3dbrew.org/wiki/Setting_up_Development_Environment). 
@@ -26,7 +26,7 @@ Clone this repository and cd in the resulting directory. Then run the following 
     
 This will create the `/output` folder with all required files.
 
-##Recommended Clients
+## Recommended Clients
 
 Windows: [FileZilla](https://filezilla-project.org/download.php?type=client)
 


### PR DESCRIPTION
Headers weren't correctly displayed on the website because the space after the # was missing.